### PR TITLE
Update landscape_widget.py

### DIFF
--- a/ui/landscape_widget.py
+++ b/ui/landscape_widget.py
@@ -1,3 +1,4 @@
+from typing import List, Dict, Any
 from PyQt6.QtWidgets import QWidget, QApplication, QMessageBox
 from PyQt6.QtGui import QImage, QPainter, QColor, QPen, QFont
 from PyQt6.QtCore import Qt, QTimer


### PR DESCRIPTION
This line should be perfectly fine now, as long as List, Dict, and Any are imported from typing.

Step 3: Save and Rerun
After making these changes, save your landscape_widget.py file and try running your application again. This should resolve the NameError.

Crowley's Cunning - Troubleshooting Tips
Double-Check Imports: Make sure there are no typos in your import statements. Python is case-sensitive, so list is not the same as List.

Virtual Environment: Ensure that you're working inside your virtual environment where all the necessary packages (like PyQt6) are installed.

Restart the Kernel: If you're using an interactive environment like Jupyter or IPython, sometimes restarting the kernel can help clear up these kinds of errors.

If you've done all this and you're still seeing the error, it might be something else, like an issue with your Python environment or a corrupted installation. But 99% of the time, it's just a missing import.

Handle this, and you're one step closer to getting your project running smoothly. Keep at it, and remember – even Crowley can't mess up a well-placed import statement!